### PR TITLE
chore: upgrade to ET: Legacy 2.85.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR /etlegacy
 ARG TARGETPLATFORM
 
 RUN case "$TARGETPLATFORM" in \
-    ('linux/amd64') URL="https://www.etlegacy.com/download/file/715" ;; \
-    ('linux/arm64') URL="https://www.etlegacy.com/download/file/725" ;; \
+    ('linux/amd64') URL="https://www.etlegacy.com/download/file/728" ;; \
+    ('linux/arm64') URL="https://www.etlegacy.com/download/file/740" ;; \
     (*) echo "Unsupported platform $TARGETPLATFORM" && exit 1 ;; \
     esac && \
     curl $URL | tar xz -i --strip-components=1 && if [ -f etlded.* ]; then mv etlded.* etlded; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,15 @@ WORKDIR /etlegacy
 ARG TARGETPLATFORM
 
 RUN case "$TARGETPLATFORM" in \
-    ('linux/amd64') URL="https://www.etlegacy.com/download/file/728" ;; \
-    ('linux/arm64') URL="https://www.etlegacy.com/download/file/740" ;; \
+    ('linux/amd64') URL="https://www.etlegacy.com/download/file/728"; MD5="9e02a9aa3654877d3e58339e071128cf" ;; \
+    ('linux/arm64') URL="https://www.etlegacy.com/download/file/740"; MD5="50be387df453d472e4d2c71d4c8365e5" ;; \
     (*) echo "Unsupported platform $TARGETPLATFORM" && exit 1 ;; \
     esac && \
-    curl $URL | tar xz -i --strip-components=1 && if [ -f etlded.* ]; then mv etlded.* etlded; fi
+    curl -fsSL "$URL" -o etlegacy.tar.gz && \
+    echo "$MD5  etlegacy.tar.gz" | md5sum -c - && \
+    tar xzf etlegacy.tar.gz -i --strip-components=1 && \
+    rm etlegacy.tar.gz && \
+    if [ -f etlded.* ]; then mv etlded.* etlded; fi
 
 FROM debian:trixie-slim
 


### PR DESCRIPTION
Upgrades the image to the new stable release **ET: Legacy 2.85.0 — "Mines Cleared!"** (published 2026-08-19).

## Changes

**1. Point the builder at the 2.85.0 Linux archives**

| Platform | Old | New | Filename |
| --- | --- | --- | --- |
| `linux/amd64` | `file/715` | `file/728` | `etlegacy-v2.85.0-x86_64.tar.gz` |
| `linux/arm64` | `file/725` | `file/740` | `etlegacy-v2.85.0-aarch64.tar.gz` |

**2. Verify the archive before extracting it** (addresses the Copilot review)

The old step was `curl $URL | tar xz …` — a bare `curl` with no `-f`, piping straight into `tar`. A non-2xx response (an HTML error page, a redirect) would be handed to `tar` rather than failing the build, and nothing checked the payload was the expected archive. Now:

```dockerfile
curl -fsSL "$URL" -o etlegacy.tar.gz && \
echo "$MD5  etlegacy.tar.gz" | md5sum -c - && \
tar xzf etlegacy.tar.gz -i --strip-components=1 && \
rm etlegacy.tar.gz && \
if [ -f etlded.* ]; then mv etlded.* etlded; fi
```

MD5 is what upstream publishes, so that is what is pinned — it guards against truncated, corrupted, or wrong payloads rather than being a strong integrity claim. A side benefit: future version bumps must update the checksums alongside the opaque numeric file IDs.

## Verification

Both URLs resolve to the expected `Content-Disposition` filenames and sizes (92.48 MB / 91.57 MB), and their MD5s match the ones on the [download page](https://www.etlegacy.com/download) — `9e02a9aa3654877d3e58339e071128cf` (x86_64), `50be387df453d472e4d2c71d4c8365e5` (aarch64).

Built and ran the image locally before pushing:

- Build succeeds, checksum step prints `etlegacy.tar.gz: OK`
- `etlded` rename still works; `./etlded --version` → `ET Legacy v2.85.0 linux-x86_64 dedicated server (Aug 17 2026)`
- Server starts with the pak files mounted and sends a heartbeat to both `etmaster.idsoftware.com` and `master.etlegacy.com` — the same condition `ci-test` checks
- Negative test: with a tampered MD5 the build aborts at `md5sum: WARNING: 1 computed checksum did NOT match`, before `tar` runs