### PR TITLE
fix(dockerfile): resolve BuildKit check warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN case "$TARGETPLATFORM" in \
 
 FROM debian:trixie-slim
 
-LABEL maintainer "Sebastian Danielsson <sebastian.danielsson@proton.me>"
+LABEL maintainer="Sebastian Danielsson <sebastian.danielsson@proton.me>"
 
 RUN groupadd -r etlegacy && useradd -g etlegacy etlegacy
 
@@ -27,7 +27,7 @@ COPY --from=builder --chown=etlegacy:etlegacy /etlegacy /etlegacy
 
 WORKDIR /etlegacy
 
-EXPOSE 27960/UDP
+EXPOSE 27960/udp
 
 USER etlegacy
 


### PR DESCRIPTION
- LegacyKeyValueFormat: use "LABEL key=value" instead of the legacy
  whitespace-separated form
- ExposeProtoCasing: lowercase the protocol in EXPOSE 27960/udp

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Bf6Qu43suhNfG1pSA1f2PH